### PR TITLE
fixed safari date bug

### DIFF
--- a/src/Hooks/useGetLatestUpdateDate.ts
+++ b/src/Hooks/useGetLatestUpdateDate.ts
@@ -4,7 +4,7 @@ import { useSubsidieContext } from "../DataProvider";
 const useGetLatestUpdateDate = () => {
   const { data } = useSubsidieContext();
 
-  return new Date(data?.[0]?.DATUM_OVERZICHT);
+  return new Date(data?.[0]?.DATUM_OVERZICHT?.substring(0, 10));
 };
 
 export default useGetLatestUpdateDate;


### PR DESCRIPTION
safari Date cannot process a date with time so we only use the date part